### PR TITLE
Feature/auto branch getting

### DIFF
--- a/Analysis/sortingChannels/BoostedTauClass.py
+++ b/Analysis/sortingChannels/BoostedTauClass.py
@@ -8,24 +8,3 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True  #Find out what does this do ?
 class BoostedTau(particle):
     def __init__(self, particleType):
         super(BoostedTau,self).__init__(particleType)
-    
-    def setUpBranches(self, wrappedOutputTree):
-        super(BoostedTau,self).setUpBranches(wrappedOutputTree)
-        for branch in boostedTauBranches.values():
-            wrappedOutputTree.branch("g{}_{}".format(self.particleType,branch[0]),"{}".format(branch[1]),lenVar="gn{}".format(self.particleType))
-    
-    def fillBranches(self,wrappedOutputTree):
-        super(BoostedTau,self).fillBranches(wrappedOutputTree)
-        for branch in boostedTauBranches.values():
-            wrappedOutputTree.fillBranch("g{}_{}".format(self.particleType,branch[0]),self.get_attributes(branch[0]))
-
-
-    
-    
-        
-
-    
-    
-    
-    
-    

--- a/Analysis/sortingChannels/ElectronClass.py
+++ b/Analysis/sortingChannels/ElectronClass.py
@@ -8,15 +8,6 @@ class Electron(particle):
     def __init__(self, particleType):
         super(Electron,self).__init__(particleType)
     
-    def setUpBranches(self, wrappedOutputTree):
-        super(Electron,self).setUpBranches(wrappedOutputTree)
-        for branch in ElectronBranches.values():
-            wrappedOutputTree.branch("g{}_{}".format(self.particleType,branch[0]),"{}".format(branch[1]),lenVar="gn{}".format(self.particleType))
-    
-    def fillBranches(self,wrappedOutputTree):
-        super(Electron,self).fillBranches(wrappedOutputTree)
-        for branch in ElectronBranches.values():
-            wrappedOutputTree.fillBranch("g{}_{}".format(self.particleType,branch[0]),self.get_attributes(branch[0]))
 
     def relativeIso(self,electronCollectionObject):
         if abs(electronCollectionObject.eta) <= 1.479:

--- a/Analysis/sortingChannels/FatJetClass.py
+++ b/Analysis/sortingChannels/FatJetClass.py
@@ -8,20 +8,3 @@ class FatJet(particle):
     def __init__(self, particleType):
         super(FatJet,self).__init__(particleType)
     
-    def setUpBranches(self, wrappedOutputTree):
-        super(FatJet,self).setUpBranches(wrappedOutputTree)
-        for branch in FatJetBranches.values():
-            wrappedOutputTree.branch("g{}_{}".format(self.particleType,branch[0]),"{}".format(branch[1]),lenVar="gn{}".format(self.particleType))
- 
-
-    
-    def fillBranches(self,wrappedOutputTree):
-        super(FatJet,self).fillBranches(wrappedOutputTree)
-        for branch in FatJetBranches.values():
-            wrappedOutputTree.fillBranch("g{}_{}".format(self.particleType,branch[0]),self.get_attributes(branch[0]))
-
-
-    
-
-
-        

--- a/Analysis/sortingChannels/MuonClass.py
+++ b/Analysis/sortingChannels/MuonClass.py
@@ -7,24 +7,12 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True  #Find out what does this do ?
 class Muon(particle):
     def __init__(self, particleType):
         super(Muon,self).__init__(particleType)
-    
-    def setUpBranches(self, wrappedOutputTree):
-        super(Muon,self).setUpBranches(wrappedOutputTree)
-        for branch in MuonBranches.values():
-            wrappedOutputTree.branch("g{}_{}".format(self.particleType,branch[0]),"{}".format(branch[1]),lenVar="gn{}".format(self.particleType))
-    
-    def fillBranches(self,wrappedOutputTree):
-        super(Muon,self).fillBranches(wrappedOutputTree)
-        for branch in MuonBranches.values():
-            wrappedOutputTree.fillBranch("g{}_{}".format(self.particleType,branch[0]),self.get_attributes(branch[0]))
 
     def apply_cut(self,l_func):
         if self.collection is None:
 	        return
-
         #self.collection = filter(self.passingMVAID,self.collection)
         self.collection = filter(l_func,self.collection)
-
     
     def passingMVAID(self,muonCollectionObject):
         print ("Testing Muon MVA ID= ",type(muonCollectionObject.mvaId),muonCollectionObject.mvaId)

--- a/Analysis/sortingChannels/TauClass.py
+++ b/Analysis/sortingChannels/TauClass.py
@@ -7,25 +7,3 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True  #Find out what does this do ?
 class Tau(particle):
     def __init__(self, particleType):
         super(Tau,self).__init__(particleType)
-    
-    def setUpBranches(self, wrappedOutputTree):
-        super(Tau,self).setUpBranches(wrappedOutputTree)
-        for branch in TauBranches.values():
-            wrappedOutputTree.branch("g{}_{}".format(self.particleType,branch[0]),"{}".format(branch[1]),lenVar="gn{}".format(self.particleType))
-    
-    def fillBranches(self,wrappedOutputTree):
-        super(Tau,self).fillBranches(wrappedOutputTree)
-        for branch in TauBranches.values():
-            wrappedOutputTree.fillBranch("g{}_{}".format(self.particleType,branch[0]),self.get_attributes(branch[0]))
-
-
-    
-    
-    
-            
-
-    
-    
-    
-    
-    

--- a/Analysis/sortingChannels/particleClass.py
+++ b/Analysis/sortingChannels/particleClass.py
@@ -4,23 +4,44 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True  #Find out what does this do ?
 import traceback
+import numpy as np
 
 class particle(object):
 	def __init__(self, particleType):
 		self.particleType = particleType # What type of particle it is Tau, Jet etc
 		self.collection = None
+		self.branch_names = dict()
+		self.branches_setup = False
 
 	#Create the new branches to be added for the selected objects. Specific bracnches for objects such as FatJets (softdropmass) can be added by writing a separate class that inherits base particle class
 	def setUpBranches(self, wrappedOutputTree):
-		wrappedOutputTree.branch("gn{}".format(self.particleType),"I")
-		wrappedOutputTree.branch("g{}_pt".format(self.particleType),"F",lenVar="gn{}".format(self.particleType))
-		wrappedOutputTree.branch("g{}_mass".format(self.particleType),"F",lenVar="gn{}".format(self.particleType))
-		wrappedOutputTree.branch("g{}_phi".format(self.particleType),"F",lenVar="gn{}".format(self.particleType))
-		wrappedOutputTree.branch("g{}_eta".format(self.particleType),"F",lenVar="gn{}".format(self.particleType))
+		if self.branches_setup:
+			return
+
+		length_name = "gn{}".format(self.particleType)
+		wrappedOutputTree.branch(length_name,"I")
+		for bName, bType in self.branch_names.iteritems():
+			wrappedOutputTree.branch("g{}_{}".format(self.particleType, bName), bType, lenVar=length_name)
+
+		self.branches_setup = True
 
 	def setupCollection(self, event):
 		self.collection = Collection(event,self.particleType)
-	
+
+		if self.branch_names:
+			return
+
+		print("here", self.particleType)
+		type_dict = {"Float_t" : "F", "Int_t": "I", "Bool_t" : "O", "UChar_t": "I"}
+		for leaf in self.collection._event._tree.GetListOfLeaves():
+			lName = leaf.GetName()
+			if "_" not in lName:
+				continue
+			partName = lName[:lName.index("_")]
+			varName = lName[lName.index("_")+1:]
+			if partName == self.particleType:
+				self.branch_names[varName] = type_dict[leaf.GetTypeName()]
+
 	#Cuts more complicated for some objects could be added in a separate class that inherits particle class
 	def apply_cut(self,l_func):
 		if self.collection is None:
@@ -29,82 +50,18 @@ class particle(object):
 	
 
 	def fillBranches(self,wrappedOutputTree):
-		if self.particleType == "Tau":
-			print("This is filling for tau = ",len(self.collection))
 		wrappedOutputTree.fillBranch("gn{}".format(self.particleType),len(self.collection))
-		wrappedOutputTree.fillBranch("g{}_pt".format(self.particleType),self.get_attributes("pt"))
-		wrappedOutputTree.fillBranch("g{}_mass".format(self.particleType),self.get_attributes("mass"))
-		wrappedOutputTree.fillBranch("g{}_phi".format(self.particleType),self.get_attributes("phi"))
-		wrappedOutputTree.fillBranch("g{}_eta".format(self.particleType),self.get_attributes("eta"))	
+		for bName in self.branch_names.keys():
+			wrappedOutputTree.fillBranch("g{}_{}".format(self.particleType, bName), self.get_attributes(bName))
+
+
 
 	def get_attributes(self,variable):
 		try:
-			#print ("This is being returned as attributes: ", [obj[variable] for obj in self.collection])
-			return [obj[variable] for obj in self.collection]
+			dtype_dict = {"I": "int", "O": "bool", "F": "float"}
+			dtype = dtype_dict[self.branch_names[variable]]
+			return np.array([obj[variable] for obj in self.collection], dtype=dtype)
 
 		except RuntimeError:
-			#print ("Please check ",variable," for ",self.particleType)
-			#print("Error:(")
-			#traceback.print_exc()
+			print("here: ", self.particleType, variable)
 			return []
-
-	
-#############################OLDER ATTEMPTS for REFERENCE###################################################################################################
-	#def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
-	#	#self.out = wrappedOutputTree
-	#	if self.particleType == "Tau": 
-	#		wrappedOutputTree.branch("ngTau","I")
-	#		wrappedOutputTree.branch("gTau_mass","F",lenVar="ngTau")
-	#		wrappedOutputTree.branch("gTau_pt","F",lenVar="ngTau")
-	#		wrappedOutputTree.branch("gTau_phi","F",lenVar="ngTau")
-	#		wrappedOutputTree.branch("gTau_eta","F",lenVar="ngTau")
-	#	
-	#	if self.particleType == "FatJet":
-	#		wrappedOutputTree.branch("ngFatJet","I")
-	#		wrappedOutputTree.branch("gFatJet_mass","F",lenVar="ngFatJet")
-	#		wrappedOutputTree.branch("gFatJet_pt","F",lenVar="ngFatJet")
-	#		wrappedOutputTree.branch("gFatJet_phi","F",lenVar="ngFatJet")
-	#		wrappedOutputTree.branch("gFatJet_eta","F",lenVar="ngFatJet")
-	#	#return self.out
-
-	#def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
-	#	pass
-
-
-	###########################Branch Filling methods of different good Objects- Need to add more a#########################################################
-	##Fill the new "good" Tau branches
-	#def fillBranchTau(self,wrappedOutputTree,particleObject):
-	#	particleArray=self.makeParticleArray(particleObject)
-	#	wrappedOutputTree.fillBranch("ngTau",len(particleObject))
-	#	wrappedOutputTree.fillBranch("gTau_mass",particleArray["mass"])
-	#	wrappedOutputTree.fillBranch("gTau_pt",particleArray["pt"])
-	#	wrappedOutputTree.fillBranch("gTau_phi",particleArray["phi"])
-
-	#Fill the new "good" FatJet branches
-	#def fillBranchFatJet(self,wrappedOutputTree,particleObject):
-	#	particleArray=self.makeParticleArray(particleObject)
-	#	wrappedOutputTree.fillBranch("ngFatJet",len(particleObject))
-	#	wrappedOutputTree.fillBranch("gFatJet_mass",particleArray["mass"]) 
-	#	wrappedOutputTree.fillBranch("gFatJet_pt",particleArray["pt"])
-	#	wrappedOutputTree.fillBranch("gFatJet_phi",particleArray["phi"])
-
-	########################################################################################################################################################
-
-
-	#Making arrays for different variables for a object so that they can be filled in their respective branches. 
-	#def makeParticleArray(self,particleObject):
-	#	particleAttributes={}
-	#	#Adding attribiutes that will be be common to almost all objetcs but if there are special ones (like softdrop mass etc) could use the self.particle and if statements for them
-	#	particleAttributes["mass"] = [particleObject[k].mass for k in range(len(particleObject))] # interating through the "good" objects collection in an event and storing their masses in a iterable
-	#	particleAttributes["eta"] = [particleObject[k].eta for k in range(len(particleObject))]
-	#	particleAttributes["phi"] = [particleObject[k].phi for k in range(len(particleObject))]
-	#	particleAttributes["pt"] = [particleObject[k].pt for k in range(len(particleObject))]
-	#	return particleAttributes
-
- #################################################################################################################################################################   
-
-
-
-
-
-


### PR DESCRIPTION
# Overview
This pull request changes the channelSplitting code to allow for dynamically getting and filling branches. The need for this comes from different branches/names in different versions of the nanoAOD files.

The code works by first initializing the collection for a given event then, from that event, get the names of all the branches that start with a certain particles name, ie "Tau_". This means all branches are saved and filled in a dynamic way that needs no input list of branches from the user

## Limitations/Tests to be done
While this allows for all the branches in a file associated with a particle, it does not ensure all the branches in a file that are needed actually exist, but this is an issue outside the purview of a PR such as this

This does raise the question of how the output files are used after are used. If multiple files are hadd'ed together, the hadding could fail or create empty branches which could cause confusion later down the pipeline. 

## Future
This code could be improved by removing now unnecessary derived particle classes. Also, the branch names could probably be accessed in the ```beginFile``` function. 